### PR TITLE
Fix some cppcheck reports:

### DIFF
--- a/ccstruct/normalis.cpp
+++ b/ccstruct/normalis.cpp
@@ -45,6 +45,8 @@ DENORM::DENORM(const DENORM &src) {
 
 
 DENORM & DENORM::operator=(const DENORM & src) {
+  if (this == &src)
+    return *this;
   Clear();
   inverse_ = src.inverse_;
   predecessor_ = src.predecessor_;

--- a/ccstruct/pageres.cpp
+++ b/ccstruct/pageres.cpp
@@ -170,6 +170,8 @@ ROW_RES::ROW_RES(bool merge_similar_words, ROW *the_row) {
 
 
 WERD_RES& WERD_RES::operator=(const WERD_RES & source) {
+  if (this == &source)
+    return *this;
   this->ELIST_LINK::operator=(source);
   Clear();
   if (source.combination) {

--- a/opencl/openclwrapper.cpp
+++ b/opencl/openclwrapper.cpp
@@ -850,12 +850,14 @@ int OpenclDevice::CompileKernelFile( GPUEnv *gpuInfo, const char *buildOption )
         b_error |= fseek( fd, 0, SEEK_SET ) < 0;
         if ( b_error )
         {
+            free(mpArryDevsID);
             return 0;
         }
 
         binary = (char*) malloc( length + 2 );
         if ( !binary )
         {
+            free(mpArryDevsID);
             return 0;
         }
 
@@ -1353,7 +1355,6 @@ OpenclDevice::pixReadMemTiffCl(const l_uint8 *data,size_t size,l_int32  n)
 	l_int32  i, pagefound;
 	PIX     *pix;
 	TIFF    *tif;
-	L_MEMSTREAM *memStream;
 	PROCNAME("pixReadMemTiffCl");
 
 	if (!data)

--- a/textord/fpchop.cpp
+++ b/textord/fpchop.cpp
@@ -813,6 +813,8 @@ C_OUTLINE *C_OUTLINE_FRAG::close() {  //join pieces
 C_OUTLINE_FRAG & C_OUTLINE_FRAG::operator= (
 const C_OUTLINE_FRAG & src       //fragment to copy
 ) {
+  if (this == &src)
+    return *this;
   if (steps != NULL)
     delete [] steps;
 


### PR DESCRIPTION
- [opencl/openclwrapper.cpp:853]: (error) Memory leak: mpArryDevsID
- [textord/fpchop.cpp:813]: (warning) 'operator=' should check for assignment to self to avoid problems with dynamic memory (+ others)
- [opencl/openclwrapper.cpp:1356]: (style) Unused variable: memStream

I noticed too these:
[classify/normmatch.cpp:104]: (error) Array 'feature.Params[1]' accessed at index 1, which is out of bounds.
[classify/normmatch.cpp:106]: (error) Array 'feature.Params[1]' accessed at index 2, which is out of bounds.
[classify/normmatch.cpp:108]: (error) Array 'feature.Params[1]' accessed at index 3, which is out of bounds.
[classify/normmatch.cpp:130]: (error) Array 'feature.Params[1]' accessed at index 2, which is out of bounds.
[classify/normmatch.cpp:138]: (error) Array 'feature.Params[1]' accessed at index 3, which is out of bounds.
[opencl/openclwrapper.cpp:2906]: (error) Array 'imageData4[4]' accessed at index 8519679, which is out of bounds.
[opencl/openclwrapper.cpp:2907]: (error) Array 'imageData4[4]' accessed at index 8519679, which is out of bounds.
[opencl/openclwrapper.cpp:2908]: (error) Array 'imageData4[4]' accessed at index 8519679, which is out of bounds.
[opencl/openclwrapper.cpp:2909]: (error) Array 'imageData4[4]' accessed at index 8519679, which is out of bounds.
but don't know how to fix them.
